### PR TITLE
Add SECURITY.md with strict vulnerability disclosure policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,38 @@
+# Security Policy
+
+## Supported Versions
+
+The maintainers provide security updates for the following versions.
+
+| Version | Supported |
+| --- | --- |
+| `main` (latest commit) | ✅ |
+| `< 1.0.0` / all older snapshots | ❌ |
+
+## API Key and Data Privacy Policy
+
+This project may require third-party API keys to enable its features.
+
+Security and privacy requirements:
+
+- All processing is performed locally or strictly client-side.
+- The project does **not** collect, log, transmit, or store user API keys on external servers.
+- The project does **not** collect, log, transmit, or store personal data on external servers.
+- Users are responsible for protecting API keys in their local environment (for example, local environment variables or local secret stores).
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, report it privately by email to:
+
+- **security@yml-helper.dev**
+
+Do **not** open a public GitHub Issue, Discussion, or Pull Request for suspected security vulnerabilities.
+
+When reporting, include:
+
+- A clear description of the issue and potential impact.
+- Reproduction steps or a minimal proof of concept.
+- Affected versions, commit hashes, and environment details.
+- Any proposed remediation, if available.
+
+The maintainers will acknowledge receipt, investigate, and coordinate responsible disclosure before any public announcement.


### PR DESCRIPTION
### Motivation

- Provide a repository-level security policy to clarify supported versions and disclosure expectations.
- Ensure strict privacy guarantees for any third-party API keys and personal data by stating processing is local/client-side only.
- Enforce a private reporting channel and prohibit public GitHub issues for security vulnerabilities to enable responsible disclosure.

### Description

- Add a new `SECURITY.md` at the repository root containing a `Supported Versions` table that lists supported branches/versions.
- Add an `API Key and Data Privacy Policy` section that explicitly states the project does not collect, log, transmit, or store user API keys or personal data on external servers.
- Add a `Reporting a Vulnerability` section requiring private reports to `security@yml-helper.dev` and forbidding public GitHub Issues, Discussions, or Pull Requests for security reports.

### Testing

- Verified the new file contents with `nl -ba SECURITY.md`, which printed the created `SECURITY.md` and its sections successfully.
- Checked working tree status with `git status --short --branch` to confirm repository state after the addition.
- No automated unit tests are required for this documentation-only change; linting/CI (if present) should be used by maintainers when merging.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69becd102d2c83318802225ddb68ef00)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive security policy documentation covering version support lifecycle, privacy practices for API keys and user data, and vulnerability disclosure procedures. Confirms all data processing occurs locally with no external collection, logging, or transmission of sensitive information. Includes private vulnerability reporting instructions and guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->